### PR TITLE
Add OpenHive — open-source Slack alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following starters supports the `@supabase/supabase-js` v2 library.
 - [Bemi for Supabase JS](https://github.com/BemiHQ/bemi-supabase-js) - Open-source platform for automatic data change tracking.
 - [Supabase automated self host](https://github.com/singh-inder/supabase-automated-self-host) - Self-host Supabase with Caddy and Authelia. Just run ONE script.
 - [Edge Worker](https://pgflow.dev) - Open-source serverless task queue worker that runs on Supabase Edge Functions (Background Tasks) and Supabase Queues. It simplifies consuming the queues and adds useful features like concurrency control, retries, and observability.
+- [OpenHive](https://github.com/arseneHuot/openhive) - Open-source, self-hosted Slack alternative with channels, DMs, threads, reactions, file uploads, and video/audio calls. Uses Supabase Auth, Realtime, Storage, and Edge Functions with 23 auto-provisioned tables.
 
 ## Online Courses
 


### PR DESCRIPTION
## What is OpenHive?

[OpenHive](https://github.com/arseneHuot/openhive) is a fully open-source, self-hosted team messaging platform — an alternative to Slack built entirely on Supabase.

## Supabase Features Used

- **Auth** — User authentication (email/password, magic link)
- **Realtime** — Live messaging, presence, typing indicators
- **Storage** — File uploads and attachments
- **Edge Functions** — LiveKit token generation, webhooks, bot events
- **PostgreSQL** — 23 tables auto-provisioned via setup wizard
- **RLS** — Row Level Security policies on all tables

## Key Features

- Channels, DMs, threaded conversations
- @mentions, emoji reactions, file uploads
- Pinned messages, read receipts
- Video/audio calls with screen sharing (LiveKit)
- Workspace management with roles

## Tech Stack

Next.js 14 (App Router) + TypeScript + Tailwind CSS + shadcn/ui + Zustand + LiveKit

## Links

- **GitHub**: https://github.com/arseneHuot/openhive
- **License**: MIT