### PR TITLE
Add WritBase to Community Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following starters supports the `@supabase/supabase-js` v2 library.
 - [Bemi for Supabase JS](https://github.com/BemiHQ/bemi-supabase-js) - Open-source platform for automatic data change tracking.
 - [Supabase automated self host](https://github.com/singh-inder/supabase-automated-self-host) - Self-host Supabase with Caddy and Authelia. Just run ONE script.
 - [Edge Worker](https://pgflow.dev) - Open-source serverless task queue worker that runs on Supabase Edge Functions (Background Tasks) and Supabase Queues. It simplifies consuming the queues and adds useful features like concurrency control, retries, and observability.
+- [WritBase](https://github.com/Writbase/writbase) - MCP-native task management for AI agent fleets, built on Supabase.
 
 ## Online Courses
 


### PR DESCRIPTION
## Summary
- Adds [WritBase](https://github.com/Writbase/writbase) to the Community Tools section
- WritBase is an MCP-native task management control plane for AI agent fleets, built on Supabase (Postgres, Edge Functions, Auth)

## Entry
Inserted alphabetically in Community Tools. Title-cased, ends with period per CONTRIBUTING guidelines.