### PR TITLE
Add Lovable Cloud to Supabase Exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The following starters supports the `@supabase/supabase-js` v2 library.
 - [Heroku to Supabase Importer](https://migrate.supabase.com/) - Given Heroku is ending free-tier support soon, if you have any PostgreSQL DB that you want to continue supporting on your projects, migrating to Supabase will be a good choice. With this tool, it will be a breeze to migrate over. Here's [a guide](https://supabase.com/docs/guides/migrations/heroku) with a video for this migration process.
 - [Supabase DB to Google Sheets](https://github.com/jadynekena/supabase-googlesheet) - Tool to pull Supabase data into Google Sheets.
 - [Retool REST API data generator](https://retool.com/api-generator) - Tool to generate structured data to be inserted into your PostgresDB.
+- [Lovable Cloud to Supabase Exporter](https://github.com/dreamlit-ai/lovable-cloud-to-supabase-exporter) - Migrate tables, users, and storage from Lovable Cloud to your own Supabase backend without password resets or manual CSV work.
 
 ## Supabase DX Tools
 


### PR DESCRIPTION
Adds [Lovable Cloud to Supabase Exporter](https://github.com/dreamlit-ai/lovable-cloud-to-supabase-exporter) to the Data Migration Tools section.

## What it does

Migrates tables, auth users (without password resets), and storage buckets from Lovable Cloud to a self-hosted Supabase backend. Lovable's built-in migration path requires manual CSV exports, individual file re-uploads, and forces every user to reset their password. This tool automates the full process.

## Why it belongs here

- Open source (MIT), documented, and actively maintained
- Directly addresses a Supabase migration use case (Lovable Cloud → self-hosted Supabase)
- Fits alongside existing Data Migration Tools entries (Heroku to Supabase Importer, Supabase Schema, etc.)
- CLI + web UI, runnable locally or via hosted version