### PR TITLE
Add VibeXForge to Community Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following starters supports the `@supabase/supabase-js` v2 library.
 - [Bemi for Supabase JS](https://github.com/BemiHQ/bemi-supabase-js) - Open-source platform for automatic data change tracking.
 - [Supabase automated self host](https://github.com/singh-inder/supabase-automated-self-host) - Self-host Supabase with Caddy and Authelia. Just run ONE script.
 - [Edge Worker](https://pgflow.dev) - Open-source serverless task queue worker that runs on Supabase Edge Functions (Background Tasks) and Supabase Queues. It simplifies consuming the queues and adds useful features like concurrency control, retries, and observability.
+- [VibeXForge](https://github.com/alex-jb/vibex) - AI-native launch platform built on Supabase Auth, RLS, and SECURITY DEFINER RPCs. Submit a URL, get a Claude-scored review, watch the project evolve through 6 RPG stages on real engagement metrics.
 
 ## Online Courses
 


### PR DESCRIPTION
Adding **VibeXForge** to `## Community Tools`.

**What it does**: AI-native launch platform for makers. Users paste a URL or GitHub repo, Claude returns a structured review across 5 dimensions (originality, clarity, UX potential, virality potential, investor curiosity), and the project becomes a 16-bit pixel-art "hero card" that evolves through 6 RPG stages on real engagement (plays / upvotes / shares).

**How Supabase is used (full backend stack)**:
- **Auth**: GitHub + Google OAuth via `@supabase/ssr` cookie flow
- **RLS**: every public table has explicit policies — anon-key only in app code, no service role
- **SECURITY DEFINER RPCs**: `increment_play`, `toggle_upvote`, `compute_evolution_stage`, `get_user_role` — atomic mutations without exposing service role
- **Realtime**: project leaderboard streams via `postgres_changes`
- **40+ migrations** with idempotent applied tracking

**Why it's a Community Tool, not a toy**: source-available, used as a launch platform for indie AI makers (open beta with Product Hunt launch on May 1, 2026). 109 commits in past 2 weeks. Bilingual EN/ZH. Live at [vibexforge.com](https://www.vibexforge.com).

Happy to adjust the description or section per your preference.