### PR TITLE
Add Puppyone to Community Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following starters supports the `@supabase/supabase-js` v2 library.
 - [Bemi for Supabase JS](https://github.com/BemiHQ/bemi-supabase-js) - Open-source platform for automatic data change tracking.
 - [Supabase automated self host](https://github.com/singh-inder/supabase-automated-self-host) - Self-host Supabase with Caddy and Authelia. Just run ONE script.
 - [Edge Worker](https://pgflow.dev) - Open-source serverless task queue worker that runs on Supabase Edge Functions (Background Tasks) and Supabase Queues. It simplifies consuming the queues and adds useful features like concurrency control, retries, and observability.
+- [Puppyone](https://github.com/puppyone-ai/puppyone) - Open-source file system for AI agents, built on Supabase (Postgres + Auth) with FastAPI. Auto-versioned writes, file-level access control (FLS), audit logs, and 15+ data connectors syncing external sources as agent-readable files. Self-hostable via Docker Compose.
 
 ## Online Courses
 


### PR DESCRIPTION
## What this adds

Adds [Puppyone](https://github.com/puppyone-ai/puppyone) to the **Community Tools** section.

## What it is

Puppyone is an open-source file system designed for AI agents, built on Supabase (Postgres + Auth) with FastAPI. It uses Supabase as the primary data and auth layer, and adds:

- **Auto-versioned writes** — every modification is snapshotted automatically
- **File-Level Security (FLS)** — per-agent access control enforced at the storage layer (similar in spirit to Supabase RLS, but at the file level)
- **15+ data connectors** — Notion, GitHub, Drive, Linear, etc. sync external sources as agent-readable files
- **Multi-channel access** — same files exposed via MCP, REST, CLI, and sandbox

## Why Supabase users may care

Built on the Supabase stack (Postgres, GoTrue, Storage / S3-compatible). Self-hostable via \`docker compose up -d\` alongside an existing Supabase instance. Apache 2.0.

- Repo: https://github.com/puppyone-ai/puppyone
- Site: https://www.puppyone.ai
- License: Apache 2.0

Made with [Cursor](https://cursor.com)