### PR TITLE
Add StatusPageBuddy to Community Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ To **enhance** this list, please refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Contents
 
-- [Official Starters](#official-starters)
-- [Community Starters](#community-starters)
-- [Data Migration Tools](#data-migration-tools)
-- [Supabase DX Tools](#supabase-dx-tools)
-- [Community Tools](#community-tools)
-- [Online Courses](#online-courses)
-- [Videos, Podcasts, Livestreams, Talks](#videos-podcasts-livestreams-talks)
-- [Integration Guides](#integration-guides)
-- [Other interesting articles](#other-interesting-articles)
+- [Awesome Supabase ](#awesome-supabase-)
+  - [Contents](#contents)
+  - [Official Starters](#official-starters)
+  - [Community Starters](#community-starters)
+  - [Data Migration Tools](#data-migration-tools)
+  - [Supabase DX Tools](#supabase-dx-tools)
+  - [Community Tools](#community-tools)
+  - [Online Courses](#online-courses)
+  - [Videos, Podcasts, Livestreams, Talks](#videos-podcasts-livestreams-talks)
+  - [Integration Guides](#integration-guides)
+  - [Other interesting articles](#other-interesting-articles)
 
 ## Official Starters
 
@@ -73,6 +75,7 @@ The following starters supports the `@supabase/supabase-js` v2 library.
 - [Bemi for Supabase JS](https://github.com/BemiHQ/bemi-supabase-js) - Open-source platform for automatic data change tracking.
 - [Supabase automated self host](https://github.com/singh-inder/supabase-automated-self-host) - Self-host Supabase with Caddy and Authelia. Just run ONE script.
 - [Edge Worker](https://pgflow.dev) - Open-source serverless task queue worker that runs on Supabase Edge Functions (Background Tasks) and Supabase Queues. It simplifies consuming the queues and adds useful features like concurrency control, retries, and observability.
+- [StatusPageBuddy](https://www.statuspagebuddy.com/) - Free hosted status pages for indie developers, built on Supabase Auth and RLS for multi-tenant isolation. 
 
 ## Online Courses
 


### PR DESCRIPTION
Adds StatusPageBuddy to the Community Tools section.

## What it is
Free hosted status pages for indie developers — built on Supabase Auth + RLS for multi-tenant isolation, with Resend SMTP for transactional email. Live product with active users.

## Why it fits Community Tools
- Built on Supabase (Auth + RLS for multi-tenant pages)
- Helps a real use case: open-source-grade status pages without Statuspage.io's $29+/month
- Side project that ships value, per CONTRIBUTING.md: *"Side projects are ok to be added if they help users to achieve a use case (they should be under Community Tools)"*

## Lint
Ran `npx awesome-lint` before and after the edit. Both runs report the same **2 pre-existing errors**, with **no new errors introduced** by this PR:
- `1:1 Awesome list must reside in a valid git repository` — fires when running on a fork; should pass once merged upstream
- `11:1 ToC item "Awesome Supabase " does not match corresponding heading "Official Starters"` — pre-existing trailing-space typo in the ToC, out of scope for this PR

## Checklist
- [x] Searched existing entries — no duplicate
- [x] Followed format `[Name](link) - Description.`
- [x] Title-cased name
- [x] Description starts with capital, ends with period
- [x] Added to bottom of Community Tools section
- [x] Ran `npx awesome-lint` — no new errors introduced
