### PR TITLE
Add commit.show

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following starters supports the `@supabase/supabase-js` v2 library.
 - [Bemi for Supabase JS](https://github.com/BemiHQ/bemi-supabase-js) - Open-source platform for automatic data change tracking.
 - [Supabase automated self host](https://github.com/singh-inder/supabase-automated-self-host) - Self-host Supabase with Caddy and Authelia. Just run ONE script.
 - [Edge Worker](https://pgflow.dev) - Open-source serverless task queue worker that runs on Supabase Edge Functions (Background Tasks) and Supabase Queues. It simplifies consuming the queues and adds useful features like concurrency control, retries, and observability.
+- [commit.show](https://github.com/commitshow/commitshow) - Public league for AI-assisted (vibe-coded) software projects, built on Supabase (Postgres + Auth + Edge Functions + Realtime). CLI audits any GitHub repo from the terminal: `npx commitshow audit github.com/owner/repo`.
 
 ## Online Courses
 


### PR DESCRIPTION
Adds commit.show — a public league for AI-assisted (vibe-coded) software projects, built end-to-end on Supabase.

Stack:
- Supabase Postgres + RLS (28 tables, 56+ policies)
- Supabase Auth (Email + Google + GitHub + X OAuth)
- Supabase Edge Functions (analyze-project, audit-preview, stripe-webhook, etc. — Deno runtime)
- Supabase Realtime (live activity feed)

The product itself: audit any GitHub repo from the terminal:

```
npx commitshow audit github.com/owner/repo
```

Returns a deterministic 100-point score, 3 strengths + 2 concerns verdict, and 7 vibe-coder failure-mode checks (including RLS coverage detection — useful as a Supabase-aware audit signal).

- Live: https://commit.show
- Main repo: https://github.com/commitshow/commitshow
- CLI: https://github.com/commitshow/cli
- MIT, free, no signup required for the audit.

Happy to adjust the entry wording per the list's style guide.