### PR TITLE
Add Altair to Community Starters

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following starters supports the `@supabase/supabase-js` v2 library.
 - [SupaSasS Lite](https://github.com/Razikus/supabase-nextjs-template) - Open source Next.js SasS template (with 2FA, and example app)
 - [SupaSocial](https://github.com/koji0701/supabase-react-social-media-starter/tree/main) - React social media starter with auth, friend requests, profile pics, and example app (profile, friends, signin, leaderboard, and more pages).
 - [Extro](https://github.com/turbostarter/extro) - Open source browser extension starter kit.
+- [Altair](https://github.com/dr-h-cyber/Altair) - Professional Services Automation starter with resourcing timeline, capacity/utilization, monthly revenue snapshots, RLS, and Casbin-based RBAC. React + TypeScript + Vite.
 
 ## Data Migration Tools
 


### PR DESCRIPTION
Adds [Altair](https://github.com/dr-h-cyber/Altair), an MIT-licensed Professional Services Automation (PSA) "exoskeleton" starter built on Supabase + React + Vite + Vercel.

It demonstrates several non-trivial Supabase patterns that may be useful as a reference:

- A single ~800-line `supabase/schema.sql` that drops cleanly into a fresh Postgres (tables, enums, RLS policies, RPC functions)
- A column-whitelist write authorization pattern (`api/_lib/auth.ts`) where the frontend never calls `supabase.from()` directly — all writes go through authed RPCs that enforce per-role column allow-lists
- Casbin layered on top of RLS for cross-cutting role checks
- A `revenue_engine.sql` that does month-end snapshot locking via Postgres functions

Format: I added it as the last item under Community Starters since it functions as a fork-and-customize starting point for building a PSA tool.