### PR TITLE
Add supabase-security-skill (RLS auditor) + supabase-security-mcp (MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The following starters supports the `@supabase/supabase-js` v2 library.
 - [Supabase CLI](https://supabase.com/docs/reference/cli) - The Supabase CLI provides tools to develop your project locally and deploy to the Supabase Platform.
 - [Supabase SQL](https://database.dev/) - Find common use case SQL scripts easily for copy pasting.
 - [Supabase Plus](https://github.com/dsplce-co/supabase-plus) - An extra set of tools for managing Supabase projects, going beyond the possibilities of the regular Supabase CLI.
+- [supabase-security-skill](https://github.com/Perufitlife/supabase-security-skill) - Open-source MIT auditor that finds RLS gaps, public storage buckets, SECURITY DEFINER functions callable by anon, and anon-grant residue (relevant to the Oct 30, 2026 default change). Probes anonymously to confirm each leak live, then outputs an HTML report with copy-paste fix SQL.
+- [supabase-security-mcp](https://www.npmjs.com/package/@perufitlife/supabase-security-mcp) - MCP server that lets AI coding agents (Claude Code, Cursor, Cline) run the security audit via natural language: "audit my Supabase project ref xxx".
 
 ## Community Tools
 


### PR DESCRIPTION
Adding two related tools to the **Supabase DX Tools** section:

### 1. supabase-security-skill — open-source RLS/SECURITY DEFINER auditor
- MIT-licensed CLI ([github.com/Perufitlife/supabase-security-skill](https://github.com/Perufitlife/supabase-security-skill))
- Probes anonymously to confirm each leak live (not just metadata inference)
- Detects: RLS gaps, public storage buckets, SECURITY DEFINER functions callable by anon, anon-grant residue (relevant to the Oct 30, 2026 default change)
- Outputs an HTML report with copy-paste fix SQL + an "Apply all" SQL bundle
- Hosted run available on Apify Store (no install): [apify.com/renzomacar/supabase-security-auditor](https://apify.com/renzomacar/supabase-security-auditor)

### 2. supabase-security-mcp — MCP server companion
- npm: [`@perufitlife/supabase-security-mcp`](https://www.npmjs.com/package/@perufitlife/supabase-security-mcp)
- Lets AI coding agents (Claude Code, Cursor, Cline, Continue) run the audit via natural language: "audit my Supabase project ref xxx"

Both tools are MIT-licensed and the user's token never leaves their machine.

Built off real findings — I scanned 100 random Supabase projects and 22% had at least one anon-readable table ([writeup](https://perufitlife.github.io/supabase-security-skill/blog/scanned-100-supabase-projects.html)).