### PR TITLE
Add rlsgrid to Supabase DX Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The following starters supports the `@supabase/supabase-js` v2 library.
 - [Supabase CLI](https://supabase.com/docs/reference/cli) - The Supabase CLI provides tools to develop your project locally and deploy to the Supabase Platform.
 - [Supabase SQL](https://database.dev/) - Find common use case SQL scripts easily for copy pasting.
 - [Supabase Plus](https://github.com/dsplce-co/supabase-plus) - An extra set of tools for managing Supabase projects, going beyond the possibilities of the regular Supabase CLI.
+- [rlsgrid](https://github.com/matte97p/rlsgrid) - Schema-driven RLS test matrix and cross-tenant fuzzer for Postgres/Supabase. Maps every role × table × operation, probes for cross-tenant leaks, and emits a pgTAP suite. CLI + GitHub Action.
 
 ## Community Tools
 


### PR DESCRIPTION
Adds [rlsgrid](https://github.com/matte97p/rlsgrid) under **Supabase DX Tools**.

rlsgrid is a schema-driven Row-Level Security test matrix and cross-tenant fuzzer for Postgres/Supabase: it reads your live schema, classifies every role × table × operation, actively probes for cross-tenant leaks, and emits a pgTAP suite. It understands the Supabase shape (anon/authenticated/service_role, JWT claims, `auth.users` foreign keys). MIT, on PyPI, with a GitHub Action.

Entry format follows CONTRIBUTING (`[resource](link) - Description.`).